### PR TITLE
Update Teilwert backend URL and headers

### DIFF
--- a/apiService.ts
+++ b/apiService.ts
@@ -55,9 +55,10 @@ async function fetchApiPost<T = any>(fullUrl: string, bodyPayload: any): Promise
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
+        'ngrok-skip-browser-warning': '69420',
       },
       body: JSON.stringify(bodyPayload),
-      mode: 'cors', 
+      mode: 'cors',
     });
 
     if (!response.ok) {

--- a/constants.ts
+++ b/constants.ts
@@ -67,6 +67,5 @@ export const DEFAULT_API_BASE_URL = "https://hutaufvine.pythonanywhere.com/data_
 // We'll handle this directly in the apiService for v2 calls, or assume it's the same base and only `database` differs.
 // For simplicity, assuming the provided DEFAULT_API_BASE_URL is for the primary product DB.
 // The new v2 database URL structure is "http://138.2.161.49:6969/kv/get_all". We will use this directly.
-export const TEILWERT_V2_API_URL = "http://138.2.161.49:6969/kv/get_all";
-
+export const TEILWERT_V2_API_URL = "https://genuine-painfully-rattler.ngrok-free.app/kv/get_all";
 export const API_BASE_URL_STORAGE_KEY = 'vineApp_apiBaseUrl';export const ADDITIONAL_EXPENSES_STORAGE_KEY = 'vineApp_additionalExpenses';

--- a/utils/apiService.ts
+++ b/utils/apiService.ts
@@ -55,9 +55,10 @@ async function fetchApiPost<T = any>(fullUrl: string, bodyPayload: any): Promise
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
+        'ngrok-skip-browser-warning': '69420',
       },
       body: JSON.stringify(bodyPayload),
-      mode: 'cors', 
+      mode: 'cors',
     });
 
     if (!response.ok) {


### PR DESCRIPTION
## Summary
- update Teilwert v2 backend URL
- include ngrok header in API requests

## Testing
- `npm run build` *(fails: `vite` not found)*
- `npx tsc --noEmit` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_b_686d9594dc28832e8685fd64faca3524