### PR TITLE
Fix Teilwert API URL

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -67,5 +67,4 @@ export const DEFAULT_API_BASE_URL = "https://hutaufvine.pythonanywhere.com/data_
 // We'll handle this directly in the apiService for v2 calls, or assume it's the same base and only `database` differs.
 // For simplicity, assuming the provided DEFAULT_API_BASE_URL is for the primary product DB.
 // The new v2 database URL structure is "http://138.2.161.49:6969/kv/get_all". We will use this directly.
-export const TEILWERT_V2_API_URL = "https://genuine-painfully-rattler.ngrok-free.app/kv/get_all";
-export const API_BASE_URL_STORAGE_KEY = 'vineApp_apiBaseUrl';export const ADDITIONAL_EXPENSES_STORAGE_KEY = 'vineApp_additionalExpenses';
+export const TEILWERT_V2_API_URL = "/kv/get_all";export const API_BASE_URL_STORAGE_KEY = 'vineApp_apiBaseUrl';export const ADDITIONAL_EXPENSES_STORAGE_KEY = 'vineApp_additionalExpenses';


### PR DESCRIPTION
## Summary
- switch Teilwert v2 URL to a relative path so `/kv/*` uses the same host

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_686ea632cc08832e876555afc458e2b0