### PR TITLE
Fix shop upload url

### DIFF
--- a/components/Pages/VermoegenPage.tsx
+++ b/components/Pages/VermoegenPage.tsx
@@ -342,7 +342,7 @@ const VermoegenPage: React.FC<VermoegenPageProps> = ({ products, additionalExpen
         });
         if (opts.publish) {
           try {
-            const resp = await fetch('hutauf.org/upload_shop', {
+            const resp = await fetch('https://hutauf.org/upload_shop', {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify(opts.name ? { html, name: opts.name } : { html })


### PR DESCRIPTION
## Summary
- use an absolute URL for the shop upload endpoint

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_687d74121f8c832b8deafc540923caaf