### PR TITLE
Handle default privatentnahmen in alternative EÜR method

### DIFF
--- a/components/Pages/EuerPage.tsx
+++ b/components/Pages/EuerPage.tsx
@@ -76,7 +76,8 @@ const EuerPage: React.FC<EuerPageProps> = ({ products, settings, onSettingsChang
         }
         // Einnahmen Privatentnahme (Teilwert im Entnahmejahr)
         const effectivePrivatentnahmeDate = getEffectivePrivatentnahmeDate(p, settings);
-        if (p.usageStatus.includes(ProductUsage.PRIVATENTNAHME) &&
+        if ((p.usageStatus.includes(ProductUsage.PRIVATENTNAHME) || !p.usageStatus.length) &&
+            !p.usageStatus.includes(ProductUsage.STORNIERT) &&
             effectivePrivatentnahmeDate &&
             effectivePrivatentnahmeDate.getFullYear().toString() === selectedYear) {
           einnahmenPrivatentnahme += wertTeilwertEntnahme;


### PR DESCRIPTION
## Summary
- Ensure EÜR's alternative method counts private withdrawals for products without explicit status, using the configured default privatentnahme date

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6894bf7f8d8c832ba7f47ef70e40467f