### PR TITLE
Clarify year context in sales headings

### DIFF
--- a/components/Pages/SalesPage.tsx
+++ b/components/Pages/SalesPage.tsx
@@ -142,7 +142,7 @@ const SalesPage: React.FC<SalesPageProps> = ({ products, onUpdateProduct, euerSe
 
       <div className="p-6 bg-slate-800 rounded-lg shadow-xl border border-slate-700">
         <h3 className="text-xl font-semibold text-gray-100 mb-4">
-          Verkaufte Produkte ({selectedPlotYear === 'all' ? 'Alle Jahre' : selectedPlotYear}): {filteredSoldProductsForTableAndPlots.length}
+          Verkaufte Produkte (verkauft in {selectedPlotYear === 'all' ? 'allen Jahren' : selectedPlotYear}): {filteredSoldProductsForTableAndPlots.length}
         </h3>
         {filteredSoldProductsForTableAndPlots.length === 0 ? (
           <div className="text-center py-10">

--- a/components/Sales/UsagePieCharts.tsx
+++ b/components/Sales/UsagePieCharts.tsx
@@ -113,7 +113,7 @@ const UsagePieCharts: React.FC<UsagePieChartsProps> = ({ products, selectedYear 
   return (
     <div className="p-4 bg-slate-750 rounded-md shadow-inner">
       <h4 className="text-md font-medium text-gray-200 mb-4 flex items-center">
-        <FaChartPie className="mr-2 text-sky-400" /> Bestandsverteilung ({selectedYear === 'all' ? 'Alle Jahre' : selectedYear})
+        <FaChartPie className="mr-2 text-sky-400" /> Bestandsverteilung (bestellt in {selectedYear === 'all' ? 'allen Jahren' : selectedYear})
       </h4>
       <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
         {renderPie(pieData.etvData, 'ETV', formatCurrency)}


### PR DESCRIPTION
## Summary
- Clarify that inventory distribution pie charts reflect items ordered in the selected year
- Indicate year of sale in sold products table header

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68988875a700832b909429bae2d0980d