### PR TITLE
Add annual EÜR detail exports (XLSX + PDF) with product-level rows

### DIFF
--- a/components/Pages/EuerPage.tsx
+++ b/components/Pages/EuerPage.tsx
@@ -1,10 +1,11 @@
 import React, { useMemo, useState } from 'react';
 import { ProductUsage, EuerPageProps, EuerSettings } from '../../types';
-import { FaCalculator, FaCog, FaInfoCircle } from 'react-icons/fa';
+import { FaCalculator, FaCog, FaFileExcel, FaFilePdf, FaInfoCircle } from 'react-icons/fa';
 import { parseGermanDate } from '../../utils/dateUtils';
 import { DEFAULT_PRIVATENTNAHME_DELAY_OPTIONS } from '../../constants';
 import { isProductIgnoredForBelegAndEuer } from '../../utils/euerUtils';
 import { getProductBookingEntries } from '../../utils/bookingUtils';
+import { buildEuerExportRows, exportEuerRowsToPdf, exportEuerRowsToXlsx } from '../../utils/euerExport';
 
 const EuerPage: React.FC<EuerPageProps> = ({ products, settings, onSettingsChange, additionalExpenses }) => {
   const [selectedYear, setSelectedYear] = useState<string>(new Date().getFullYear().toString());
@@ -116,6 +117,24 @@ const EuerPage: React.FC<EuerPageProps> = ({ products, settings, onSettingsChang
     return new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(value);
   };
 
+  const handleExportXlsx = () => {
+    const rows = buildEuerExportRows(products, settings, selectedYear);
+    if (!rows.length) {
+      alert(`Keine produktbezogenen EÜR-Daten für ${selectedYear} gefunden.`);
+      return;
+    }
+    exportEuerRowsToXlsx(rows, selectedYear);
+  };
+
+  const handleExportPdf = () => {
+    const rows = buildEuerExportRows(products, settings, selectedYear);
+    if (!rows.length) {
+      alert(`Keine produktbezogenen EÜR-Daten für ${selectedYear} gefunden.`);
+      return;
+    }
+    exportEuerRowsToPdf(rows, selectedYear);
+  };
+
   return (
     <div className="space-y-8">
       <div className="p-6 bg-slate-800 rounded-lg shadow-xl border border-slate-700">
@@ -223,9 +242,31 @@ const EuerPage: React.FC<EuerPageProps> = ({ products, settings, onSettingsChang
       </div>
 
       <div className="p-6 bg-slate-800 rounded-lg shadow-xl border border-slate-700">
-        <h2 className="text-2xl font-semibold text-gray-100 mb-6 flex items-center">
-          <FaCalculator className="mr-3 text-sky-400" /> Einnahmenüberschussrechnung für {euerData.year}
-        </h2>
+        <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center mb-6 gap-3">
+          <h2 className="text-2xl font-semibold text-gray-100 flex items-center">
+            <FaCalculator className="mr-3 text-sky-400" /> Einnahmenüberschussrechnung für {euerData.year}
+          </h2>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={handleExportXlsx}
+              className="inline-flex items-center px-3 py-2 rounded-md bg-emerald-600 hover:bg-emerald-500 text-white text-sm font-medium transition-colors"
+              title={`EÜR Details ${selectedYear} als XLSX exportieren`}
+            >
+              <FaFileExcel className="mr-2" />
+              XLSX Export
+            </button>
+            <button
+              type="button"
+              onClick={handleExportPdf}
+              className="inline-flex items-center px-3 py-2 rounded-md bg-rose-600 hover:bg-rose-500 text-white text-sm font-medium transition-colors"
+              title={`EÜR Details ${selectedYear} als PDF exportieren`}
+            >
+              <FaFilePdf className="mr-2" />
+              PDF Export
+            </button>
+          </div>
+        </div>
         <div className="space-y-4">
           <div className="p-3 bg-slate-700 rounded-md">
             <div className="flex justify-between items-center">

--- a/utils/euerExport.ts
+++ b/utils/euerExport.ts
@@ -1,0 +1,188 @@
+import { jsPDF } from 'jspdf';
+import * as XLSX from 'xlsx';
+import { EuerSettings, Product, ProductUsage } from '../types';
+import { parseGermanDate } from './dateUtils';
+import { getProductBookingEntries } from './bookingUtils';
+import { isProductIgnoredForBelegAndEuer } from './euerUtils';
+
+export interface EuerExportRow {
+  ASIN: string;
+  Name: string;
+  ETV: number;
+  Teilwert: number | null;
+  Bestelldatum: string;
+  Status: string;
+  Einnahmen_aus_Verkaeufen: number;
+  Einnahmen_Produktzugaenge: number;
+  Einnahmen_Privatentnahmen: number;
+  Ausgaben_Anlagevermoegen: number;
+  Ausgaben_Umlaufvermoegen: number;
+}
+
+const asCurrency = (value: number): string =>
+  new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(value);
+
+const round2 = (value: number): number => Math.round(value * 100) / 100;
+
+export const buildEuerExportRows = (
+  products: Product[],
+  settings: EuerSettings,
+  selectedYear: string
+): EuerExportRow[] => {
+  const rows: EuerExportRow[] = [];
+
+  products.forEach((product) => {
+    if (isProductIgnoredForBelegAndEuer(product, settings)) return;
+
+    let einnahmenAusVerkaeufen = 0;
+    let einnahmenProduktzugaenge = 0;
+    let einnahmenPrivatentnahmen = 0;
+    let ausgabenAnlagevermoegen = 0;
+    let ausgabenUmlaufvermoegen = 0;
+
+    const entries = getProductBookingEntries(product, settings);
+    entries.forEach((entry) => {
+      if (entry.amount == null) return;
+      if (entry.date.getUTCFullYear().toString() !== selectedYear) return;
+
+      if (entry.type === 'Einnahme') {
+        einnahmenProduktzugaenge += entry.amount;
+      } else if (entry.type === 'Entnahme') {
+        einnahmenPrivatentnahmen += entry.amount;
+      } else if (entry.type === 'Ausgabe') {
+        if (product.usageStatus.includes(ProductUsage.BETRIEBLICHE_NUTZUNG)) {
+          ausgabenAnlagevermoegen += entry.amount;
+        } else if (
+          product.usageStatus.includes(ProductUsage.LAGER) ||
+          product.usageStatus.includes(ProductUsage.VERKAUFT) ||
+          product.usageStatus.includes(ProductUsage.ENTSORGT)
+        ) {
+          ausgabenUmlaufvermoegen += entry.amount;
+        } else {
+          ausgabenAnlagevermoegen += entry.amount;
+        }
+      }
+    });
+
+    if (
+      product.usageStatus.includes(ProductUsage.VERKAUFT) &&
+      product.salePrice != null &&
+      product.saleDate
+    ) {
+      const saleDate = parseGermanDate(product.saleDate);
+      if (saleDate && saleDate.getFullYear().toString() === selectedYear) {
+        einnahmenAusVerkaeufen += product.salePrice;
+      }
+    }
+
+    const contributes =
+      einnahmenAusVerkaeufen !== 0 ||
+      einnahmenProduktzugaenge !== 0 ||
+      einnahmenPrivatentnahmen !== 0 ||
+      ausgabenAnlagevermoegen !== 0 ||
+      ausgabenUmlaufvermoegen !== 0;
+
+    if (!contributes) return;
+
+    rows.push({
+      ASIN: product.ASIN,
+      Name: product.name,
+      ETV: product.etv,
+      Teilwert: product.myTeilwert ?? product.teilwert ?? product.teilwert_v2 ?? null,
+      Bestelldatum: product.date,
+      Status: product.usageStatus.join(', '),
+      Einnahmen_aus_Verkaeufen: round2(einnahmenAusVerkaeufen),
+      Einnahmen_Produktzugaenge: round2(einnahmenProduktzugaenge),
+      Einnahmen_Privatentnahmen: round2(einnahmenPrivatentnahmen),
+      Ausgaben_Anlagevermoegen: round2(ausgabenAnlagevermoegen),
+      Ausgaben_Umlaufvermoegen: round2(ausgabenUmlaufvermoegen),
+    });
+  });
+
+  return rows.sort((a, b) => a.ASIN.localeCompare(b.ASIN));
+};
+
+export const exportEuerRowsToXlsx = (rows: EuerExportRow[], selectedYear: string): void => {
+  const worksheet = XLSX.utils.json_to_sheet(rows);
+  const workbook = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(workbook, worksheet, `EÜR ${selectedYear}`);
+
+  const keys = Object.keys(rows[0] || {});
+  worksheet['!cols'] = keys.map((key) => {
+    const maxValueLength = Math.max(
+      key.length,
+      ...rows.map((row) => String(row[key as keyof EuerExportRow] ?? '').length)
+    );
+    return { wch: Math.min(maxValueLength + 2, 50) };
+  });
+
+  XLSX.writeFile(workbook, `EUER_Detail_${selectedYear}.xlsx`);
+};
+
+export const exportEuerRowsToPdf = (rows: EuerExportRow[], selectedYear: string): void => {
+  const doc = new jsPDF({ unit: 'mm', format: 'a4' });
+  const margin = 10;
+  const pageWidth = doc.internal.pageSize.getWidth();
+  const pageHeight = doc.internal.pageSize.getHeight();
+  const lineHeight = 6;
+
+  const columns = [
+    { key: 'ASIN', title: 'ASIN', width: 28 },
+    { key: 'ETV', title: 'ETV', width: 20 },
+    { key: 'Einnahmen_aus_Verkaeufen', title: 'Verkauf', width: 24 },
+    { key: 'Einnahmen_Produktzugaenge', title: 'Produktzug.', width: 28 },
+    { key: 'Einnahmen_Privatentnahmen', title: 'Privatent.', width: 26 },
+    { key: 'Ausgaben_Anlagevermoegen', title: 'Anlage-A.', width: 24 },
+    { key: 'Ausgaben_Umlaufvermoegen', title: 'Umlauf-A.', width: 24 },
+  ] as const;
+
+  const drawHeader = (y: number): number => {
+    doc.setFont('helvetica', 'bold');
+    doc.setFontSize(9);
+    let x = margin;
+    columns.forEach((column) => {
+      doc.text(column.title, x, y);
+      x += column.width;
+    });
+    doc.line(margin, y + 1, pageWidth - margin, y + 1);
+    return y + lineHeight;
+  };
+
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(12);
+  doc.text(`EÜR Detailexport ${selectedYear}`, margin, margin);
+
+  let y = drawHeader(margin + 8);
+  doc.setFont('helvetica', 'normal');
+  doc.setFontSize(8);
+
+  rows.forEach((row) => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = drawHeader(margin);
+      doc.setFont('helvetica', 'normal');
+      doc.setFontSize(8);
+    }
+
+    const values = [
+      row.ASIN,
+      asCurrency(row.ETV),
+      asCurrency(row.Einnahmen_aus_Verkaeufen),
+      asCurrency(row.Einnahmen_Produktzugaenge),
+      asCurrency(row.Einnahmen_Privatentnahmen),
+      asCurrency(row.Ausgaben_Anlagevermoegen),
+      asCurrency(row.Ausgaben_Umlaufvermoegen),
+    ];
+
+    let x = margin;
+    values.forEach((value, idx) => {
+      const column = columns[idx];
+      const text = idx === 0 ? value : value.replace('€', '').trim();
+      doc.text(text, x, y);
+      x += column.width;
+    });
+    y += lineHeight;
+  });
+
+  doc.save(`EUER_Detail_${selectedYear}.pdf`);
+};


### PR DESCRIPTION
### Motivation
- Provide a per-product, year-scoped export for the EÜR summary so users can audit and sum the exact product contributions behind the on-site totals. 
- Support both `XLSX` (spreadsheet-friendly, left-side product metadata + right-side EÜR columns) and `PDF` (compact tabular view with ASIN/ETV left) outputs. 

### Description
- Added a new helper module `utils/euerExport.ts` that implements `buildEuerExportRows`, `exportEuerRowsToXlsx` and `exportEuerRowsToPdf` to produce one row per contributing product and map values into EÜR columns (Verkauf, Produktzugänge, Privatentnahmen, Ausgaben Anlage-/Umlaufvermögen).  
- The XLSX export writes product metadata (ASIN, Name, ETV, Teilwert, Bestelldatum, Status) on the left and the EÜR contribution columns on the right so spreadsheet `SUMME()` calls reproduce the UI totals.  
- The PDF export renders a paginated table with `ASIN` + `ETV` left and the EÜR contribution columns to the right.  
- Integrated export buttons into the EÜR summary card (`components/Pages/EuerPage.tsx`) with handlers that build rows for the currently selected year and call the corresponding export functions, including a user alert when no product-contributing rows exist.  

### Testing
- Built the production bundle with `npm run build` and the build completed successfully.  
- No unit tests were added; the change was validated via the production build output only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e10a9a92948330b682ad19afc28c50)