### PR TITLE
Fix: Privatentnahme im selben Jahr -> nur Einnahme auch bei undefinierter Nutzung

### DIFF
--- a/utils/bookingUtils.ts
+++ b/utils/bookingUtils.ts
@@ -26,7 +26,7 @@ export const getProductBookingEntries = (product: Product, settings: EuerSetting
   const isLagerOrBusiness = product.usageStatus.includes(ProductUsage.LAGER) || product.usageStatus.includes(ProductUsage.BETRIEBLICHE_NUTZUNG);
   const sameYearPrivateOnlyMode = Boolean(
     settings.privatentnahmeSameYearAsOnlyIncome &&
-    product.usageStatus.includes(ProductUsage.PRIVATENTNAHME) &&
+    isPrivatentnahmeOrDefault &&
     effectivePrivatentnahmeDate &&
     effectivePrivatentnahmeDate.getUTCFullYear() === orderDate.getUTCFullYear()
   );


### PR DESCRIPTION
### Motivation
- Die Einstellung `privatentnahmeSameYearAsOnlyIncome` sollte auch greifen, wenn ein Produkt keine explizite Nutzungs-Statusangabe hat (Default-Pfad), aktuell führte das zu falschen `Ausgabe`/`Entnahme`-Buchungen.

### Description
- In `utils/bookingUtils.ts` wurde die Bedingung für den Same-Year-Modus angepasst: ersetzt `product.usageStatus.includes(ProductUsage.PRIVATENTNAHME)` durch `isPrivatentnahmeOrDefault`, so dass Produkte mit leerer `usageStatus`-Liste ebenfalls als Privatentnahme-Default behandelt werden.

### Testing
- Erfolgreicher Produktions-Build mit `npm run build`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e15c0cc260833092a20f4174538189)