### PR TITLE
Show N/A when Teilwert is missing in Vermögen tab

### DIFF
--- a/components/Pages/VermoegenPage.tsx
+++ b/components/Pages/VermoegenPage.tsx
@@ -26,7 +26,8 @@ const VermoegenPage: React.FC<VermoegenPageProps> = ({ products, additionalExpen
   const [publishedUrl, setPublishedUrl] = useState<string | null>(null);
   const [editingProduct, setEditingProduct] = useState<Product | null>(null);
 
-  const getCalculatedTeilwert = (product: Product): number => product.myTeilwert ?? product.teilwert ?? 0; // <--- MODIFIED HERE
+  const hasTeilwert = (product: Product): boolean => product.myTeilwert != null || product.teilwert != null;
+  const getCalculatedTeilwert = (product: Product): number => product.myTeilwert ?? product.teilwert ?? 0;
 
   const umlaufvermoegen = useMemo(() => {
     return products
@@ -229,7 +230,7 @@ const VermoegenPage: React.FC<VermoegenPageProps> = ({ products, additionalExpen
                   <td className="px-4 py-3 text-sm text-gray-200 max-w-xs truncate" title={p.name}>{p.name}</td>
                   <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-300">{formatDate(p.orderDateObj)}</td>
                   <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-300 text-right">{formatCurrency(p.etv)}</td>
-                  <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-300 text-right">{formatCurrency(getCalculatedTeilwert(p))}</td>
+                  <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-300 text-right">{hasTeilwert(p) ? formatCurrency(getCalculatedTeilwert(p)) : 'N/A'}</td>
                   <td className="px-4 py-3 whitespace-nowrap text-sm">
                     <Button size="sm" variant="ghost" onClick={() => setEditingProduct(p)} title="Produkt bearbeiten">
                       <FaEdit />


### PR DESCRIPTION
### Motivation
- In the Vermögen table a product without a `myTeilwert` or `teilwert` was displayed as `0,00 €`, but it should show `N/A` while section/product sums must still treat missing Teilwert as zero.

### Description
- Added a helper `hasTeilwert(product: Product)` and updated the Teilwert cell rendering in `components/Pages/VermoegenPage.tsx` to display `N/A` when neither `myTeilwert` nor `teilwert` is present, while keeping `getCalculatedTeilwert` and the summary/sum calculations unchanged.

### Testing
- Ran `npm run build` successfully (Vite production build completed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1cae79ae88330a926d2ced37139dc)