### PR TITLE
Scanner & Lagerort-Management: API-Service und UI-Scaffolding

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -886,6 +886,8 @@ const App: React.FC = () => {
             onUpdateProduct={handleSaveProductDetails}
             euerSettings={euerSettings}
             belegSettings={belegSettings}
+            apiToken={apiToken}
+            apiBaseUrl={apiBaseUrl}
             onOpenBelegeTab={handleOpenBelegeTab}
           />
         )}

--- a/components/Pages/DashboardPage.tsx
+++ b/components/Pages/DashboardPage.tsx
@@ -6,6 +6,7 @@ import FileUpload from '../Products/FileUpload';
 import ProductPlots from '../Dashboard/ProductPlots';
 import { FaFilter, FaTimes, FaSearch } from 'react-icons/fa';
 import { parseDMYtoDate } from '../../utils/dateUtils';
+import ScannerPanel from '../Scanner/ScannerPanel';
 
 interface DashboardPageProps {
   products: Product[];
@@ -209,6 +210,15 @@ const DashboardPage: React.FC<DashboardPageProps> = ({
       </div>
 
       <div>
+        <div className="mb-4">
+          <ScannerPanel
+            title="Scanner (Dashboard)"
+            helpText="Scannt EAN/FNSKU. Bei Treffer: Produktdetail öffnen. Bei unbekanntem Code: ASIN-Verknüpfungsdialog öffnen."
+            onDetected={(code) => {
+              console.log('Dashboard scan detected:', code);
+            }}
+          />
+        </div>
         <h2 className="text-2xl font-semibold text-gray-100 mb-4">Produktliste ({filteredProducts.length})</h2>
         {filteredProducts.length > 0 ? (
             <ProductTable 

--- a/components/Pages/VermoegenPage.tsx
+++ b/components/Pages/VermoegenPage.tsx
@@ -1,5 +1,5 @@
 
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Product, ProductUsage, AdditionalExpense, VermoegenPageProps } from '../../types';
 import { FaArchive, FaSort, FaSortUp, FaSortDown, FaBuilding, FaPlusCircle, FaTrashAlt, FaDollarSign, FaEdit } from 'react-icons/fa';
 import { parseDMYtoDate, parseGermanDate, normalizeGermanDateInput, convertGermanToISO, convertISOToGerman, getTodayGermanFormat } from '../../utils/dateUtils';
@@ -12,12 +12,12 @@ import ScannerPanel from '../Scanner/ScannerPanel';
 import StorageLocationManager from '../Storage/StorageLocationManager';
 import LocationInventoryAuditView from '../Storage/LocationInventoryAuditView';
 import Modal from '../Common/Modal';
-import { StorageLocationEntry } from '../../utils/storageLocationService';
+import { deleteStorageLocation, listStorageLocations, StorageLocationEntry, UpdateStorageLocationInput, updateStorageLocations } from '../../utils/storageLocationService';
 
 type ProductSortKey = 'ASIN' | 'name' | 'date' | 'etv' | 'calculatedTeilwert';
 type ExpenseSortKey = 'date' | 'name' | 'amount';
 
-const VermoegenPage: React.FC<VermoegenPageProps> = ({ products, additionalExpenses, onAddExpense, onDeleteExpense, onUpdateProduct, euerSettings, belegSettings, onOpenBelegeTab }) => {
+const VermoegenPage: React.FC<VermoegenPageProps> = ({ products, additionalExpenses, onAddExpense, onDeleteExpense, onUpdateProduct, euerSettings, belegSettings, apiToken, apiBaseUrl, onOpenBelegeTab }) => {
   const [productSortKey, setProductSortKey] = useState<ProductSortKey>('date');
   const [productSortOrder, setProductSortOrder] = useState<'asc' | 'desc'>('desc');
   
@@ -32,6 +32,38 @@ const VermoegenPage: React.FC<VermoegenPageProps> = ({ products, additionalExpen
   const [editingProduct, setEditingProduct] = useState<Product | null>(null);
   const [locations, setLocations] = useState<StorageLocationEntry[]>([]);
   const [activeAuditLocation, setActiveAuditLocation] = useState<string | null>(null);
+
+  useEffect(() => {
+    const loadLocations = async () => {
+      if (!apiToken) return;
+      const response = await listStorageLocations(apiBaseUrl, apiToken);
+      if (response.status === 'success' && response.data) {
+        setLocations(response.data);
+      }
+    };
+    loadLocations();
+  }, [apiBaseUrl, apiToken]);
+
+  const handleSaveLocations = async (entries: UpdateStorageLocationInput[]) => {
+    if (!apiToken) return;
+    const response = await updateStorageLocations(apiBaseUrl, apiToken, entries);
+    if (response.status === 'success') {
+      const reloaded = await listStorageLocations(apiBaseUrl, apiToken);
+      if (reloaded.status === 'success' && reloaded.data) setLocations(reloaded.data);
+    } else {
+      alert(response.message || 'Fehler beim Speichern der Lagerorte.');
+    }
+  };
+
+  const handleDeleteLocation = async (locationId: string) => {
+    if (!apiToken) return;
+    const response = await deleteStorageLocation(apiBaseUrl, apiToken, locationId);
+    if (response.status === 'success') {
+      setLocations((prev) => prev.filter((loc) => loc.location_id !== locationId));
+    } else {
+      alert(response.message || 'Fehler beim Löschen des Lagerortes.');
+    }
+  };
 
   const hasTeilwert = (product: Product): boolean => product.myTeilwert != null || product.teilwert != null;
   const getCalculatedTeilwert = (product: Product): number => product.myTeilwert ?? product.teilwert ?? 0;
@@ -275,8 +307,8 @@ const VermoegenPage: React.FC<VermoegenPageProps> = ({ products, additionalExpen
       <StorageLocationManager
         locations={locations}
         products={products}
-        onSave={async (entries) => setLocations((prev) => [...prev, ...entries.map((entry) => ({ location_id: entry.location_id, timestamp: entry.timestamp ?? Math.floor(Date.now() / 1000), value: entry.value }))])}
-        onDelete={async (locationId) => setLocations((prev) => prev.filter((loc) => loc.location_id !== locationId))}
+        onSave={handleSaveLocations}
+        onDelete={handleDeleteLocation}
         onOpenAudit={(locationId) => setActiveAuditLocation(locationId)}
         onPrintLabel={(locationId) => console.log('Print location label:', locationId)}
       />

--- a/components/Pages/VermoegenPage.tsx
+++ b/components/Pages/VermoegenPage.tsx
@@ -8,6 +8,11 @@ import CreateShopModal from '../Shop/CreateShopModal';
 import PublishedUrlModal from '../Shop/PublishedUrlModal';
 import { generateShopHtml } from '../../utils/shopGenerator';
 import EditProductModal from '../Products/EditProductModal';
+import ScannerPanel from '../Scanner/ScannerPanel';
+import StorageLocationManager from '../Storage/StorageLocationManager';
+import LocationInventoryAuditView from '../Storage/LocationInventoryAuditView';
+import Modal from '../Common/Modal';
+import { StorageLocationEntry } from '../../utils/storageLocationService';
 
 type ProductSortKey = 'ASIN' | 'name' | 'date' | 'etv' | 'calculatedTeilwert';
 type ExpenseSortKey = 'date' | 'name' | 'amount';
@@ -25,6 +30,8 @@ const VermoegenPage: React.FC<VermoegenPageProps> = ({ products, additionalExpen
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [publishedUrl, setPublishedUrl] = useState<string | null>(null);
   const [editingProduct, setEditingProduct] = useState<Product | null>(null);
+  const [locations, setLocations] = useState<StorageLocationEntry[]>([]);
+  const [activeAuditLocation, setActiveAuditLocation] = useState<string | null>(null);
 
   const hasTeilwert = (product: Product): boolean => product.myTeilwert != null || product.teilwert != null;
   const getCalculatedTeilwert = (product: Product): number => product.myTeilwert ?? product.teilwert ?? 0;
@@ -264,6 +271,18 @@ const VermoegenPage: React.FC<VermoegenPageProps> = ({ products, additionalExpen
 
   return (
     <div className="space-y-8">
+      <ScannerPanel title="Scanner (Vermögen/Lager)" helpText="Scannt Produktcodes und startet Routing/Verknüpfung je nach Treffer." onDetected={(code) => console.log('Vermögen scan detected:', code)} />
+      <StorageLocationManager
+        locations={locations}
+        products={products}
+        onSave={async (entries) => setLocations((prev) => [...prev, ...entries.map((entry) => ({ location_id: entry.location_id, timestamp: entry.timestamp ?? Math.floor(Date.now() / 1000), value: entry.value }))])}
+        onDelete={async (locationId) => setLocations((prev) => prev.filter((loc) => loc.location_id !== locationId))}
+        onOpenAudit={(locationId) => setActiveAuditLocation(locationId)}
+        onPrintLabel={(locationId) => console.log('Print location label:', locationId)}
+      />
+      <Modal isOpen={!!activeAuditLocation} onClose={() => setActiveAuditLocation(null)} title={`Inventur · ${activeAuditLocation ?? ''}`} size="lg">
+        {activeAuditLocation && <LocationInventoryAuditView locationId={activeAuditLocation} products={products} />}
+      </Modal>
       {renderProductTable(umlaufvermoegen, "Umlaufvermögen", <FaArchive className="mr-3 text-sky-400"/>, true, sumETVUmlauf, sumTeilwertUmlauf, "Umlaufvermögen")}
       {renderProductTable(anlagenverzeichnis, "Anlagenverzeichnis", <FaBuilding className="mr-3 text-sky-400"/>, true, sumETVAnlage, sumTeilwertAnlage, "Anlagenverzeichnis")}
       

--- a/components/Pages/VermoegenPage.tsx
+++ b/components/Pages/VermoegenPage.tsx
@@ -35,7 +35,11 @@ const VermoegenPage: React.FC<VermoegenPageProps> = ({ products, additionalExpen
 
   useEffect(() => {
     const loadLocations = async () => {
-      if (!apiToken) return;
+      if (!apiToken) {
+        setLocations([]);
+        setActiveAuditLocation(null);
+        return;
+      }
       const response = await listStorageLocations(apiBaseUrl, apiToken);
       if (response.status === 'success' && response.data) {
         setLocations(response.data);

--- a/components/Scanner/ScannerPanel.tsx
+++ b/components/Scanner/ScannerPanel.tsx
@@ -1,0 +1,47 @@
+import React, { useState } from 'react';
+import Button from '../Common/Button';
+
+interface ScannerPanelProps {
+  title: string;
+  helpText?: string;
+  onDetected: (code: string) => Promise<void> | void;
+}
+
+const ScannerPanel: React.FC<ScannerPanelProps> = ({ title, helpText, onDetected }) => {
+  const [manualCode, setManualCode] = useState('');
+  const [isScanning, setIsScanning] = useState(false);
+
+  const triggerScan = async () => {
+    if (!manualCode.trim()) return;
+    await onDetected(manualCode.trim());
+    setManualCode('');
+  };
+
+  return (
+    <div className="p-4 rounded-lg border border-slate-700 bg-slate-800 space-y-3">
+      <h3 className="text-lg font-semibold text-gray-100">{title}</h3>
+      {helpText && <p className="text-sm text-gray-400">{helpText}</p>}
+      <div className="flex gap-2">
+        <input
+          value={manualCode}
+          onChange={(e) => setManualCode(e.target.value)}
+          placeholder="Barcode/QR-Code"
+          className="flex-1 px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-gray-100"
+        />
+        <Button onClick={triggerScan} disabled={!manualCode.trim()}>
+          Prüfen
+        </Button>
+      </div>
+      <Button variant="secondary" onClick={() => setIsScanning((prev) => !prev)}>
+        {isScanning ? 'Kamera-Scanner stoppen' : 'Kamera-Scanner starten'}
+      </Button>
+      {isScanning && (
+        <div className="text-xs text-gray-400">
+          Kamera-Scanner-Platzhalter (z. B. html5-qrcode). Verbinden Sie den Decoder-Callback mit <code>onDetected(code)</code>.
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ScannerPanel;

--- a/components/Storage/LocationInventoryAuditView.tsx
+++ b/components/Storage/LocationInventoryAuditView.tsx
@@ -8,7 +8,7 @@ interface LocationInventoryAuditViewProps {
 }
 
 const LocationInventoryAuditView: React.FC<LocationInventoryAuditViewProps> = ({ locationId, products }) => {
-  const expected = useMemo(() => products.filter((p: any) => p.storageLocationId === locationId), [products, locationId]);
+  const expected = useMemo(() => products.filter((p) => p.storageLocationId === locationId), [products, locationId]);
   const [scanned, setScanned] = useState<Set<string>>(new Set());
   const [error, setError] = useState<string | null>(null);
 
@@ -17,7 +17,7 @@ const LocationInventoryAuditView: React.FC<LocationInventoryAuditViewProps> = ({
   }, [expected, scanned]);
 
   const onDetected = (code: string) => {
-    const match = expected.find((p) => p.ASIN === code || (p as any).barcode === code);
+    const match = expected.find((p) => p.ASIN === code);
     if (!match) {
       setError(`Produkt ${code} gehört laut System nicht zu Lagerort ${locationId}.`);
       return;

--- a/components/Storage/LocationInventoryAuditView.tsx
+++ b/components/Storage/LocationInventoryAuditView.tsx
@@ -1,0 +1,48 @@
+import React, { useMemo, useState } from 'react';
+import { Product } from '../../types';
+import ScannerPanel from '../Scanner/ScannerPanel';
+
+interface LocationInventoryAuditViewProps {
+  locationId: string;
+  products: Product[];
+}
+
+const LocationInventoryAuditView: React.FC<LocationInventoryAuditViewProps> = ({ locationId, products }) => {
+  const expected = useMemo(() => products.filter((p: any) => p.storageLocationId === locationId), [products, locationId]);
+  const [scanned, setScanned] = useState<Set<string>>(new Set());
+  const [error, setError] = useState<string | null>(null);
+
+  const ordered = useMemo(() => {
+    return [...expected].sort((a, b) => Number(scanned.has(a.ASIN)) - Number(scanned.has(b.ASIN)));
+  }, [expected, scanned]);
+
+  const onDetected = (code: string) => {
+    const match = expected.find((p) => p.ASIN === code || (p as any).barcode === code);
+    if (!match) {
+      setError(`Produkt ${code} gehört laut System nicht zu Lagerort ${locationId}.`);
+      return;
+    }
+    setError(null);
+    setScanned((prev) => new Set(prev).add(match.ASIN));
+  };
+
+  return (
+    <div className="space-y-4">
+      <ScannerPanel title={`Inventur-Scan · ${locationId}`} helpText="Scannt korrekte Produkte grün ab und verschiebt sie ans Listenende." onDetected={onDetected} />
+      {error && <div className="p-3 rounded bg-red-950 text-red-300 text-sm">{error}</div>}
+      <ul className="space-y-2">
+        {ordered.map((p) => {
+          const ok = scanned.has(p.ASIN);
+          return (
+            <li key={p.ASIN} className={`p-3 rounded border ${ok ? 'bg-green-900/30 border-green-600' : 'bg-slate-800 border-slate-700'}`}>
+              <div className="text-sm text-gray-100">{p.name}</div>
+              <div className="text-xs text-gray-400">ASIN: {p.ASIN}</div>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+};
+
+export default LocationInventoryAuditView;

--- a/components/Storage/StorageLocationManager.tsx
+++ b/components/Storage/StorageLocationManager.tsx
@@ -17,7 +17,7 @@ const StorageLocationManager: React.FC<StorageLocationManagerProps> = ({ locatio
 
   const assignedCountMap = useMemo(() => {
     const counts = new Map<string, number>();
-    products.forEach((product: any) => {
+    products.forEach((product) => {
       const locationId = product.storageLocationId;
       if (!locationId) return;
       counts.set(locationId, (counts.get(locationId) ?? 0) + 1);

--- a/components/Storage/StorageLocationManager.tsx
+++ b/components/Storage/StorageLocationManager.tsx
@@ -1,0 +1,65 @@
+import React, { useMemo, useState } from 'react';
+import Button from '../Common/Button';
+import { Product } from '../../types';
+import { StorageLocationEntry, UpdateStorageLocationInput } from '../../utils/storageLocationService';
+
+interface StorageLocationManagerProps {
+  locations: StorageLocationEntry[];
+  products: Product[];
+  onSave: (entries: UpdateStorageLocationInput[]) => Promise<void>;
+  onDelete: (locationId: string) => Promise<void>;
+  onOpenAudit: (locationId: string) => void;
+  onPrintLabel: (locationId: string, options: { withMeta: boolean }) => void;
+}
+
+const StorageLocationManager: React.FC<StorageLocationManagerProps> = ({ locations, products, onSave, onDelete, onOpenAudit, onPrintLabel }) => {
+  const [newLocationId, setNewLocationId] = useState('');
+
+  const assignedCountMap = useMemo(() => {
+    const counts = new Map<string, number>();
+    products.forEach((product: any) => {
+      const locationId = product.storageLocationId;
+      if (!locationId) return;
+      counts.set(locationId, (counts.get(locationId) ?? 0) + 1);
+    });
+    return counts;
+  }, [products]);
+
+  return (
+    <div className="p-6 bg-slate-800 rounded-lg border border-slate-700 space-y-4">
+      <h3 className="text-xl font-semibold text-gray-100">Lagerort-Verwaltung</h3>
+      <div className="flex gap-2">
+        <input
+          value={newLocationId}
+          onChange={(e) => setNewLocationId(e.target.value)}
+          placeholder="Neuer Lagerort (location_id)"
+          className="flex-1 px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-gray-100"
+        />
+        <Button onClick={() => onSave([{ location_id: newLocationId.trim(), value: { status: 'free' } }])} disabled={!newLocationId.trim()}>
+          Anlegen
+        </Button>
+      </div>
+
+      <ul className="space-y-2">
+        {locations.map((location) => {
+          const assignedCount = assignedCountMap.get(location.location_id) ?? 0;
+          const isEmpty = assignedCount === 0;
+          return (
+            <li key={location.location_id} className="p-3 bg-slate-700 rounded-md flex items-center justify-between">
+              <button className="text-left" onClick={() => onOpenAudit(location.location_id)}>
+                <div className="text-gray-100 font-medium">{location.location_id}</div>
+                <div className="text-xs text-gray-400">Produkte: {assignedCount}</div>
+              </button>
+              <div className="flex gap-2">
+                <Button size="sm" variant="secondary" onClick={() => onPrintLabel(location.location_id, { withMeta: true })}>QR drucken</Button>
+                <Button size="sm" variant="danger" onClick={() => onDelete(location.location_id)} disabled={!isEmpty}>Löschen</Button>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+};
+
+export default StorageLocationManager;

--- a/types.ts
+++ b/types.ts
@@ -30,6 +30,7 @@ export interface Product {
   festgeschrieben?: 1;
   rechnungsNummer?: string;
   entnahmeBelegNummer?: string;
+  storageLocationId?: string;
 }
 
 

--- a/types.ts
+++ b/types.ts
@@ -90,6 +90,8 @@ export interface VermoegenPageProps {
   onUpdateProduct: (product: Product) => Promise<void>;
   euerSettings: EuerSettings;
   belegSettings: BelegSettings;
+  apiToken: string | null;
+  apiBaseUrl: string;
   onOpenBelegeTab?: (options: { invoiceNumber?: string; entnahmeBelegNummer?: string; asin?: string }) => void;
 }
 

--- a/utils/apiService.ts
+++ b/utils/apiService.ts
@@ -24,6 +24,7 @@ export interface ProductApiValue {
   festgeschrieben?: 1; // New field
   rechnungsNummer?: string; // New field
   entnahmeBelegNummer?: string;
+  storageLocationId?: string;
 }
 
 // This is the structure of an entry as defined by the API for the main product database
@@ -117,6 +118,7 @@ const productToApiValue = (product: Product): ProductApiValue => {
     ...(apiValueFields.festgeschrieben !== undefined && { festgeschrieben: apiValueFields.festgeschrieben }),
     ...(apiValueFields.rechnungsNummer !== undefined && { rechnungsNummer: apiValueFields.rechnungsNummer }),
     ...(apiValueFields.entnahmeBelegNummer !== undefined && { entnahmeBelegNummer: apiValueFields.entnahmeBelegNummer }),
+    ...(apiValueFields.storageLocationId !== undefined && { storageLocationId: apiValueFields.storageLocationId }),
   };
   return apiValue;
 };
@@ -150,6 +152,7 @@ const apiEntryToProduct = (apiEntry: ApiProductEntry): Product => {
       festgeschrieben: valueData.festgeschrieben === 1 ? 1 : undefined,
       rechnungsNummer: valueData.rechnungsNummer || undefined, 
       entnahmeBelegNummer: valueData.entnahmeBelegNummer || undefined,
+      storageLocationId: valueData.storageLocationId || undefined,
     };
 
     if (!/^\d{2}\/\d{2}\/\d{4}$/.test(product.date)) {

--- a/utils/storageLocationService.ts
+++ b/utils/storageLocationService.ts
@@ -1,0 +1,97 @@
+export interface DataOperationResponse<T> {
+  status: 'success' | 'error';
+  message?: string;
+  data?: T;
+  inserted?: number;
+  updated?: number;
+  skipped?: number;
+}
+
+export interface StorageLocationValue {
+  status?: 'free' | 'occupied' | string;
+  note?: string;
+  [key: string]: unknown;
+}
+
+export interface StorageLocationEntry {
+  location_id: string;
+  timestamp: number;
+  value: StorageLocationValue;
+}
+
+interface RawStorageLocationEntry {
+  location_id: string;
+  timestamp: number;
+  value: string;
+}
+
+async function postDataOperation<T>(baseUrl: string, token: string, request: string, payload?: unknown): Promise<DataOperationResponse<T>> {
+  const response = await fetch(baseUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'ngrok-skip-browser-warning': '69420' },
+    body: JSON.stringify({ token, request, ...(payload !== undefined ? { payload } : {}) }),
+    mode: 'cors',
+  });
+
+  if (!response.ok) {
+    return { status: 'error', message: `HTTP ${response.status}: ${response.statusText}` };
+  }
+
+  return response.json() as Promise<DataOperationResponse<T>>;
+}
+
+function parseLocation(entry: RawStorageLocationEntry): StorageLocationEntry {
+  let parsedValue: StorageLocationValue = {};
+  try {
+    parsedValue = JSON.parse(entry.value ?? '{}') as StorageLocationValue;
+  } catch {
+    parsedValue = {};
+  }
+
+  return {
+    location_id: entry.location_id,
+    timestamp: entry.timestamp,
+    value: parsedValue,
+  };
+}
+
+export async function listStorageLocations(baseUrl: string, token: string): Promise<DataOperationResponse<StorageLocationEntry[]>> {
+  const result = await postDataOperation<RawStorageLocationEntry[]>(baseUrl, token, 'list_storage_locations');
+  if (result.status !== 'success' || !result.data) return result as DataOperationResponse<StorageLocationEntry[]>;
+
+  return { ...result, data: result.data.map(parseLocation) };
+}
+
+export async function getStorageLocationsByIds(baseUrl: string, token: string, locationIds: string[]): Promise<DataOperationResponse<StorageLocationEntry[]>> {
+  const result = await postDataOperation<RawStorageLocationEntry[]>(baseUrl, token, 'get_storage_location', locationIds);
+  if (result.status !== 'success' || !result.data) return result as DataOperationResponse<StorageLocationEntry[]>;
+
+  return { ...result, data: result.data.map(parseLocation) };
+}
+
+export interface UpdateStorageLocationInput {
+  location_id: string;
+  timestamp?: number;
+  value: StorageLocationValue;
+}
+
+export async function updateStorageLocations(baseUrl: string, token: string, entries: UpdateStorageLocationInput[]): Promise<DataOperationResponse<null>> {
+  const now = Math.floor(Date.now() / 1000);
+  const payload = entries.map((entry) => ({
+    location_id: entry.location_id,
+    timestamp: entry.timestamp ?? now,
+    value: JSON.stringify(entry.value),
+  }));
+
+  return postDataOperation<null>(baseUrl, token, 'update_storage_location', payload);
+}
+
+export async function mergeStorageLocationValue(baseUrl: string, token: string, locationId: string, partialValue: StorageLocationValue): Promise<DataOperationResponse<null>> {
+  return updateStorageLocations(baseUrl, token, [
+    {
+      location_id: locationId,
+      timestamp: 0,
+      value: partialValue,
+    },
+  ]);
+}

--- a/utils/storageLocationService.ts
+++ b/utils/storageLocationService.ts
@@ -103,3 +103,13 @@ export async function mergeStorageLocationValue(baseUrl: string, token: string, 
     },
   ]);
 }
+
+export async function deleteStorageLocation(baseUrl: string, token: string, locationId: string): Promise<DataOperationResponse<null>> {
+  return updateStorageLocations(baseUrl, token, [
+    {
+      location_id: locationId,
+      timestamp: Math.floor(Date.now() / 1000),
+      value: { deleted: true },
+    },
+  ]);
+}

--- a/utils/storageLocationService.ts
+++ b/utils/storageLocationService.ts
@@ -26,18 +26,26 @@ interface RawStorageLocationEntry {
 }
 
 async function postDataOperation<T>(baseUrl: string, token: string, request: string, payload?: unknown): Promise<DataOperationResponse<T>> {
-  const response = await fetch(baseUrl, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', 'ngrok-skip-browser-warning': '69420' },
-    body: JSON.stringify({ token, request, ...(payload !== undefined ? { payload } : {}) }),
-    mode: 'cors',
-  });
+  try {
+    const response = await fetch(baseUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'ngrok-skip-browser-warning': '69420' },
+      body: JSON.stringify({ token, request, ...(payload !== undefined ? { payload } : {}) }),
+      mode: 'cors',
+    });
 
-  if (!response.ok) {
-    return { status: 'error', message: `HTTP ${response.status}: ${response.statusText}` };
+    if (!response.ok) {
+      return { status: 'error', message: `HTTP ${response.status}: ${response.statusText}` };
+    }
+
+    try {
+      return (await response.json()) as DataOperationResponse<T>;
+    } catch (error) {
+      return { status: 'error', message: `Ungültige JSON-Antwort vom Server: ${error instanceof Error ? error.message : 'Unknown parse error'}` };
+    }
+  } catch (error) {
+    return { status: 'error', message: `Netzwerkfehler bei /data_operations: ${error instanceof Error ? error.message : 'Unknown network error'}` };
   }
-
-  return response.json() as Promise<DataOperationResponse<T>>;
 }
 
 function parseLocation(entry: RawStorageLocationEntry): StorageLocationEntry {


### PR DESCRIPTION
### Motivation
- Erweiterung der App um Barcode/QR-Scan-Workflows, zentrale Lagerort-Verwaltung und einen Inventur-Modus auf Lagerort-Ebene zur besseren Lagerverwaltung.
- Backend-Interaktion für Lagerorte soll über die vorhandene `/data_operations`-Schnittstelle erfolgen, wobei `value` immer als stringified JSON gespeichert und `timestamp == 0` für partielle Merge-Updates verwendet wird.

### Description
- Neuer TypeScript-Service `utils/storageLocationService.ts` mit typsicheren Funktionen `listStorageLocations`, `getStorageLocationsByIds`, `updateStorageLocations` und `mergeStorageLocationValue`, wobei `value` vor dem Senden per `JSON.stringify` konvertiert und `timestamp` korrekt gesetzt wird.
- Wiederverwendbare Scanner-UI `components/Scanner/ScannerPanel.tsx` mit manueller Eingabe und klarem Integrationspunkt für Kamera-Decoder-Callback via `onDetected(code)` (Platzhalter für `html5-qrcode`).
- Zentrale Lagerort-UI `components/Storage/StorageLocationManager.tsx` zum Anlegen, Auflisten, Drucken (Hook) und Löschen von Lagerorten; Löschaktion ist durch Zählung zugewiesener Produkte geschützt (nur leere Orte löschbar).
- Inventur-/Audit-Ansicht `components/Storage/LocationInventoryAuditView.tsx` zeigt erwartete Produkte eines Lagerorts, markiert bei Scan korrekte Artikel grün und gibt sofortiges Fehlerfeedback bei Fremdscans.
- Scanner-Panel integriert in `components/Pages/DashboardPage.tsx` und `components/Pages/VermoegenPage.tsx`, und initiales Modal-Wiring für Inventur im Vermögen-Tab hinzugefügt; Produkt-zu-Lagerort-Feld wird aktuell als `storageLocationId` erwartet (UI-Scaffolding vorbereitet).

### Testing
- `npm run build` (Vite production build) wurde ausgeführt und erfolgreich abgeschlossen, die Anwendung lässt sich bundlen (es wurden nur Warnungen zu großen Chunks ausgegeben). 
- Die neuen TypeScript-Dateien wurden typisiert und in die bestehenden Pages eingebunden; es gibt keine zusätzlichen automatisierten Unit-Tests in diesem PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1f00649f8833089406bb6c8425c98)