### PR TITLE
Improve scanner UX: stop on success, persist camera, and clarify scan areas

### DIFF
--- a/components/Products/EditProductModal.tsx
+++ b/components/Products/EditProductModal.tsx
@@ -4,7 +4,7 @@ import { Product, ProductUsage, EuerSettings, BelegSettings, ProductHistoryEntry
 import { PRODUCT_USAGE_OPTIONS } from '../../constants';
 import Modal from '../Common/Modal';
 import Button from '../Common/Button';
-import { FaRegCalendarCheck, FaExclamationTriangle, FaSave, FaCheckCircle } from 'react-icons/fa';
+import { FaRegCalendarCheck, FaExclamationTriangle, FaSave, FaCheckCircle, FaWarehouse, FaBarcode } from 'react-icons/fa';
 import {
     parseGermanDate,
     getTodayGermanFormat,
@@ -391,11 +391,18 @@ const EditProductModal: React.FC<EditProductModalProps> = ({
                 className="block w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded-md shadow-sm text-gray-100 focus:outline-none focus:ring-sky-500 focus:border-sky-500 sm:text-sm"
               />
             </div>
-            <ScannerPanel 
+            <div className="rounded-md border border-sky-700/60 bg-sky-900/20 p-2">
+              <div className="flex items-center gap-2 text-sky-200 mb-2 text-sm font-medium">
+                <FaWarehouse />
+                <span>Lagerort-Scan</span>
+              </div>
+              <ScannerPanel 
               title="Lagerort scannen" 
               helpText="Scannen Sie einen Lagerort-QR-Code, um das Produkt direkt zuzuordnen."
+              cameraPreferenceKey="storage-location"
               onDetected={(code) => handleChange('storageLocationId', code)}
             />
+            </div>
           </div>
         </div>
         
@@ -411,12 +418,18 @@ const EditProductModal: React.FC<EditProductModalProps> = ({
               ))}
             </ul>
           )}
-          <ScannerPanel 
+          <div className="rounded-md border border-violet-700/60 bg-violet-900/20 p-2">
+            <div className="flex items-center gap-2 text-violet-200 mb-2 text-sm font-medium">
+              <FaBarcode />
+              <span>Produktcode-Scan</span>
+            </div>
+            <ScannerPanel 
             title="Neuen Code scannen" 
             helpText="Scannen Sie einen Barcode oder QR-Code, um ihn diesem Produkt zuzuordnen."
+            cameraPreferenceKey="product-code"
             onDetected={(code) => {
               if (code === product.ASIN) {
-                alert(`Der gescannte Code ist die ASIN (${code}). Dies ist dem Produkt ohnehin fest zugeordnet und muss nicht als extra Barcode gespeichert werden.`);
+                alert(`Erfolgreich gescannt: ${code}. Das ist die ASIN dieses Produkts und daher bereits hinterlegt.`);
               } else if (formData.barcodes.includes(code)) {
                 alert(`Der Code ${code} ist bereits in der Liste vorhanden.`);
               } else {
@@ -424,6 +437,7 @@ const EditProductModal: React.FC<EditProductModalProps> = ({
               }
             }}
           />
+          </div>
         </div>
 
         <div className="mt-4">

--- a/components/Scanner/ScannerPanel.tsx
+++ b/components/Scanner/ScannerPanel.tsx
@@ -6,15 +6,19 @@ interface ScannerPanelProps {
   title: string;
   helpText?: string;
   onDetected: (code: string) => Promise<void> | void;
+  cameraPreferenceKey?: string;
 }
 
-const ScannerPanel: React.FC<ScannerPanelProps> = ({ title, helpText, onDetected }) => {
+const ScannerPanel: React.FC<ScannerPanelProps> = ({ title, helpText, onDetected, cameraPreferenceKey = 'default' }) => {
   const [manualCode, setManualCode] = useState('');
   const [isScanning, setIsScanning] = useState(false);
   const [cameras, setCameras] = useState<CameraDevice[]>([]);
   const [selectedCamera, setSelectedCamera] = useState<string>('');
+  const [lastSuccessCode, setLastSuccessCode] = useState<string>('');
   const scannerRef = useRef<Html5Qrcode | null>(null);
+  const isHandlingDetectionRef = useRef(false);
   const lastScannedRef = useRef<{code: string, time: number} | null>(null);
+  const cameraStorageKey = `scanner:lastCamera:${cameraPreferenceKey}`;
   const scannerContainerId = useMemo(() => `qr-reader-${title.replace(/[^a-z0-9]/gi, '')}-${Math.random().toString(36).substring(7)}`, [title]);
 
   const playSound = () => {
@@ -24,7 +28,13 @@ const ScannerPanel: React.FC<ScannerPanelProps> = ({ title, helpText, onDetected
     } catch (e) {}
   };
 
-  const handleDetect = (code: string) => {
+  const findBestDefaultCamera = (devices: CameraDevice[]) => {
+    const preferred = devices.find((cam) => /back|rear|environment|rück/i.test(cam.label || ''));
+    return preferred?.id || devices[0]?.id || '';
+  };
+
+  const handleDetect = async (code: string) => {
+    if (isHandlingDetectionRef.current) return;
     const now = Date.now();
     if (lastScannedRef.current) {
       const { code: lastCode, time: lastTime } = lastScannedRef.current;
@@ -33,10 +43,16 @@ const ScannerPanel: React.FC<ScannerPanelProps> = ({ title, helpText, onDetected
         return;
       }
     }
+    isHandlingDetectionRef.current = true;
     lastScannedRef.current = { code, time: now };
     playSound();
+    setLastSuccessCode(code);
     setIsScanning(false); // Stop scanner automatically after a successful read
-    onDetected(code);
+    try {
+      await onDetected(code);
+    } finally {
+      isHandlingDetectionRef.current = false;
+    }
   };
 
   const triggerScan = async () => {
@@ -54,8 +70,10 @@ const ScannerPanel: React.FC<ScannerPanelProps> = ({ title, helpText, onDetected
         if (!isMounted) return;
         if (devices && devices.length) {
           setCameras(devices);
-          const defaultCamId = selectedCamera || devices[0].id;
-          if (!selectedCamera) setSelectedCamera(devices[0].id);
+          const storedCamId = localStorage.getItem(cameraStorageKey);
+          const knownStoredCam = storedCamId && devices.some((d) => d.id === storedCamId) ? storedCamId : '';
+          const defaultCamId = selectedCamera || knownStoredCam || findBestDefaultCamera(devices);
+          if (!selectedCamera && defaultCamId) setSelectedCamera(defaultCamId);
           
           const html5QrCode = new Html5Qrcode(scannerContainerId);
           scannerRef.current = html5QrCode;
@@ -99,7 +117,7 @@ const ScannerPanel: React.FC<ScannerPanelProps> = ({ title, helpText, onDetected
     return () => {
       isMounted = false;
     };
-  }, [isScanning, scannerContainerId, onDetected, selectedCamera]);
+  }, [cameraStorageKey, isScanning, scannerContainerId, onDetected, selectedCamera]);
 
   // Handle unmount cleanup separately so it only runs when the component actually unmounts
   useEffect(() => {
@@ -148,15 +166,17 @@ const ScannerPanel: React.FC<ScannerPanelProps> = ({ title, helpText, onDetected
           <select
             value={selectedCamera}
             onChange={(e) => {
+              const nextCamera = e.target.value;
+              localStorage.setItem(cameraStorageKey, nextCamera);
               // Stop current scan before changing camera state
               if (scannerRef.current) {
                 setIsScanning(false);
                 setTimeout(() => {
-                  setSelectedCamera(e.target.value);
+                  setSelectedCamera(nextCamera);
                   setIsScanning(true);
                 }, 500); // Give it half a second to completely tear down
               } else {
-                setSelectedCamera(e.target.value);
+                setSelectedCamera(nextCamera);
               }
             }}
             className="px-3 py-2 bg-slate-700 border border-slate-600 rounded-md shadow-sm text-gray-100 text-sm"
@@ -171,6 +191,12 @@ const ScannerPanel: React.FC<ScannerPanelProps> = ({ title, helpText, onDetected
       <div className={`mt-4 bg-slate-200 rounded-lg overflow-hidden ${isScanning ? 'block' : 'hidden'}`}>
         <div id={scannerContainerId}></div>
       </div>
+
+      {lastSuccessCode && !isScanning && (
+        <div className="text-emerald-300 text-sm bg-emerald-900/30 border border-emerald-700 rounded-md px-3 py-2">
+          Erfolgreich gescannt: <span className="font-mono">{lastSuccessCode}</span>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
### Motivation
- Prevent the camera scanner from continuously firing after a successful detection and give clear feedback about a completed scan. 
- Remember the user-selected camera between scanner openings so mobile users don't repeatedly get the front camera. 
- Make the product detail scanning UI clearer by visually separating warehouse scans from product-code scans.

### Description
- Updated `ScannerPanel` to block duplicate callbacks during processing via `isHandlingDetectionRef`, stop scanning on first successful read, and retain the last scanned value in `lastSuccessCode` shown as `Erfolgreich gescannt`. 
- Added camera preference support with a `cameraPreferenceKey` prop and per-key persistence using `localStorage` (key format `scanner:lastCamera:<key>`) and a smarter default selection that prefers back/rear/environment cameras. 
- Improved UX in `EditProductModal` by wrapping the warehouse scanner and product-code scanner in distinct styled containers with `FaWarehouse` and `FaBarcode` icons and by passing `cameraPreferenceKey` values (`storage-location` and `product-code`). 
- Adjusted ASIN handling so scanning the product ASIN confirms success to the user (alert) while still avoiding duplicate barcode entries.

### Testing
- Ran `npm run build` which exercised the changes but the build failed in this environment due to an unresolved module error for `html5-qrcode`, so runtime bundling could not be fully validated. 
- No unit tests were added or modified for this change and no other automated test suites were executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2813faf988330aa1dbfdf293a7bd7)