### PR TITLE
Make ASIN clickable in Vermögen table

### DIFF
--- a/components/Pages/VermoegenPage.tsx
+++ b/components/Pages/VermoegenPage.tsx
@@ -290,7 +290,11 @@ const VermoegenPage: React.FC<VermoegenPageProps> = ({ products, additionalExpen
                       setSelectedAsins(set);
                     }} />
                   </td>
-                  <td className="px-4 py-3 whitespace-nowrap text-sm text-sky-400">{p.ASIN}</td>
+                  <td className="px-4 py-3 whitespace-nowrap text-sm text-sky-400">
+                    <a href={`https://www.amazon.de/dp/${p.ASIN}`} target="_blank" rel="noopener noreferrer" className="hover:underline">
+                      {p.ASIN}
+                    </a>
+                  </td>
                   <td className="px-4 py-3 text-sm text-gray-200 max-w-xs truncate" title={p.name}>{p.name}</td>
                   <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-300">{formatDate(p.orderDateObj)}</td>
                   <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-300 text-right">{formatCurrency(p.etv)}</td>


### PR DESCRIPTION
### Motivation
- Make ASINs in the Vermögen product table actionable by linking each ASIN to its Amazon product page at `https://www.amazon.de/dp/<ASIN>` for quick lookup.

### Description
- Replaced the plain ASIN cell with an anchor element in `components/Pages/VermoegenPage.tsx` that points to `https://www.amazon.de/dp/${p.ASIN}` and uses `target="_blank"` and `rel="noopener noreferrer"` and preserved styling with a `hover:underline` class.

### Testing
- Ran `git status --short`, `git add` and `git commit` for the change and the commit succeeded. 
- Verified the modified lines with `nl -ba components/Pages/VermoegenPage.tsx | sed -n '288,306p'` and the output shows the new anchor markup.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9a0dfad4c83308c335663f245c658)